### PR TITLE
Limit lecture picker

### DIFF
--- a/src/app/(main)/lecture/[id]/lecture-picker.tsx
+++ b/src/app/(main)/lecture/[id]/lecture-picker.tsx
@@ -12,6 +12,7 @@ function getMonday(d: Date) {
   return new Date(newDate.setUTCHours(0,0,0,0));
 }
 
+
 function getFriday(d: Date) {
   d = new Date(d);
   var day = d.getDay(),


### PR DESCRIPTION
El seleccionador de clases de la pagina de asistencias ahora solo muestra las clases del profesor correspondientes a la semana actual.